### PR TITLE
Add completion_char feature

### DIFF
--- a/crates/libtiny_tui/src/config.rs
+++ b/crates/libtiny_tui/src/config.rs
@@ -31,6 +31,9 @@ pub(crate) struct Config {
 
     #[serde(default)]
     pub(crate) key_map: Option<KeyMap>,
+
+    #[serde(default)]
+    pub(crate) completion_char: Option<String>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]

--- a/crates/libtiny_tui/src/input_area/mod.rs
+++ b/crates/libtiny_tui/src/input_area/mod.rs
@@ -712,7 +712,7 @@ impl InputArea {
 }
 
 impl InputArea {
-    pub(crate) fn autocomplete(&mut self, dict: &Trie) {
+    pub(crate) fn autocomplete(&mut self, dict: &Trie, completion_char: &Option<String>) {
         if self.in_autocomplete() {
             // scroll next if you hit the KeyAction::InputAutoComplete key again
             self.completion_prev_entry();
@@ -746,7 +746,17 @@ impl InputArea {
                 }
             };
 
-            dict.drop_pfx(&mut word.iter().cloned())
+            let mut completions = dict.drop_pfx(&mut word.iter().cloned());
+
+            if let Some(completion_suffix) = &completion_char {
+                if cursor_left == 0 {
+                    for completion in completions.iter_mut() {
+                        completion.push_str(&format!("{} ", completion_suffix));
+                    }
+                }
+            }
+
+            completions
         };
 
         if !completions.is_empty() {

--- a/crates/libtiny_tui/src/messaging.rs
+++ b/crates/libtiny_tui/src/messaging.rs
@@ -169,7 +169,8 @@ impl MessagingUI {
             }
             KeyAction::InputAutoComplete => {
                 if self.exit_dialogue.is_none() {
-                    self.input_field.autocomplete(&self.nicks, &self.completion_char);
+                    self.input_field
+                        .autocomplete(&self.nicks, &self.completion_char);
                 }
                 WidgetRet::KeyHandled
             }

--- a/crates/libtiny_tui/src/messaging.rs
+++ b/crates/libtiny_tui/src/messaging.rs
@@ -39,6 +39,9 @@ pub(crate) struct MessagingUI {
 
     /// Last timestamp added to the UI.
     last_ts: Option<Timestamp>,
+
+    // Autocompletion character to be used when at the start of the line. Set with `set_completion_char`.
+    completion_char: Option<String>,
 }
 
 /// Length of ": " suffix of nicks in messages
@@ -92,6 +95,7 @@ impl MessagingUI {
         height: i32,
         scrollback: usize,
         msg_layout: Layout,
+        completion_char: Option<String>,
     ) -> MessagingUI {
         MessagingUI {
             msg_area: MsgArea::new(width, height - 1, scrollback, msg_layout),
@@ -102,6 +106,7 @@ impl MessagingUI {
             nicks: Trie::new(),
             last_activity_line: None,
             last_ts: None,
+            completion_char,
         }
     }
 
@@ -164,7 +169,7 @@ impl MessagingUI {
             }
             KeyAction::InputAutoComplete => {
                 if self.exit_dialogue.is_none() {
-                    self.input_field.autocomplete(&self.nicks);
+                    self.input_field.autocomplete(&self.nicks, &self.completion_char);
                 }
                 WidgetRet::KeyHandled
             }
@@ -216,6 +221,11 @@ impl MessagingUI {
     /// Set input field contents.
     pub(crate) fn set_input_field(&mut self, str: &str) {
         self.input_field.set(str)
+    }
+
+    /// Set completion char.
+    pub(crate) fn set_completion_char(&mut self, completion_char: Option<String>) {
+        self.completion_char = completion_char;
     }
 
     /// Set cursor location in the input field.

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -108,6 +108,9 @@ pub struct TUI {
 
     /// TabConfig settings loaded from config file
     tab_configs: TabConfigs,
+
+    // Autocompletion character to be used when at the start of the line.
+    completion_char: Option<String>,
 }
 
 pub(crate) enum CmdResult {
@@ -175,6 +178,7 @@ impl TUI {
             key_map: KeyMap::default(),
             config_path,
             tab_configs: TabConfigs::default(),
+            completion_char: None,
         };
 
         // Init "mentions" tab. This needs to happen right after creating the TUI to be able to
@@ -365,9 +369,11 @@ impl TUI {
                 max_nick_length,
                 key_map,
                 layout,
+                completion_char,
                 ..
             } = config;
             self.set_colors(colors);
+            self.set_completion_char(completion_char);
             self.scrollback = scrollback.max(1);
             self.key_map.load(&key_map.unwrap_or_default());
             if let Some(layout) = layout {
@@ -392,6 +398,13 @@ impl TUI {
         self.tb
             .set_clear_attributes(colors.clear.fg as u8, colors.clear.bg as u8);
         self.colors = colors;
+    }
+
+    fn set_completion_char(&mut self, completion_char: Option<String>) {
+        self.completion_char = completion_char;
+        for tab in &mut self.tabs {
+            tab.widget.set_completion_char((&self.completion_char).clone());
+        }
     }
 
     fn new_tab(&mut self, idx: usize, src: MsgSource, alias: Option<String>) {
@@ -446,6 +459,7 @@ impl TUI {
                     self.height - 1,
                     self.scrollback,
                     self.msg_layout,
+                    self.completion_char.clone(),
                 ),
                 src,
                 style: TabStyle::Normal,

--- a/crates/libtiny_tui/src/tui.rs
+++ b/crates/libtiny_tui/src/tui.rs
@@ -403,7 +403,8 @@ impl TUI {
     fn set_completion_char(&mut self, completion_char: Option<String>) {
         self.completion_char = completion_char;
         for tab in &mut self.tabs {
-            tab.widget.set_completion_char((&self.completion_char).clone());
+            tab.widget
+                .set_completion_char((&self.completion_char).clone());
         }
     }
 


### PR DESCRIPTION
Implements the feature described in [Issue #402](https://github.com/osa1/tiny/issues/402).
To add the completion_char, add the following line to the config:

```
completion_char: ":"
```

The character will only be appended to a completion at the start of the line.